### PR TITLE
Disable testing to fix build error

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -72,6 +72,7 @@ build() {
   # Build project
   cmake ${srcdir}/${_dir} \
         -DCATKIN_BUILD_BINARY_PACKAGE=ON \
+        -DCATKIN_ENABLE_TESTING=OFF \
         -DCMAKE_INSTALL_PREFIX=/opt/ros/noetic \
         -DPYTHON_EXECUTABLE=/usr/bin/python \
         -DSETUPTOOLS_DEB_LAYOUT=OFF


### PR DESCRIPTION
At present https://download.ros.org seems to be down which is causing build failures for this package as testing data cannot be downloaded. Fix by disabling testing, as we don't need it anyway.